### PR TITLE
Update Munki Python path

### DIFF
--- a/AddOptionalInstalls.py
+++ b/AddOptionalInstalls.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 
 import os
 import plistlib

--- a/BulkAddModifyManifests.py
+++ b/BulkAddModifyManifests.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 
 import argparse
 import copy

--- a/MoveIncludedManifestsToSubfolder.py
+++ b/MoveIncludedManifestsToSubfolder.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/python
+#!/usr/local/munki/munki-python
 
 '''
 This script moves all top-level Munki manifests to the top-level of the manifests directory


### PR DESCRIPTION
Munki no longer uses `/usr/local/munki/python`, so this PR updates for the new path.