### PR TITLE
Check for any Santa in uninstall_check script

### DIFF
--- a/pkgsinfo/santa-2021.2.pkginfo
+++ b/pkgsinfo/santa-2021.2.pkginfo
@@ -192,7 +192,7 @@ exit 0
 	<string>#!/bin/zsh
 
 # See if the system extension is still enabled
-sysexttest=$(/usr/bin/systemextensionsctl list | /usr/bin/grep "com.google.santa.daemon" | /usr/bin/grep "activated enabled")
+sysexttest=$(/usr/bin/systemextensionsctl list | /usr/bin/grep "com.google.santa.daemon")
 
 if [[ -z "$sysexttest" ]]; then
     /bin/echo "Santa system extension unloaded."


### PR DESCRIPTION
This is because, even with a restart required, a second restart (based on my testing) may be needed to fully unload the system extension.

So the first time, Munki will consider this still installed if it's activated and enabled.

The second time, Munki will still consider this installed because it's pending reboot, and so will require another reboot.

After that second reboot, the system extension is fully unloaded.