### PR TITLE
Add postinstall_script to Chrome pkginfo

### DIFF
--- a/pkgsinfo/GoogleChromeInstallCheck.pkginfo
+++ b/pkgsinfo/GoogleChromeInstallCheck.pkginfo
@@ -153,6 +153,12 @@ if __name__ == '__main__':
 	<string>10.11.0</string>
 	<key>name</key>
 	<string>GoogleChrome</string>
+	<key>postinstall_script</key>
+	<string>#!/bin/zsh
+
+# Since the installcheck_script checks for the running version of Chrome, kill any existing (stray) Chrome processes, as Munki may end up in an install loop otherwise. Blocking applications based on the installs array means Chrome should already not be running.
+/usr/bin/killall "Google Chrome"
+</string>
 	<key>unattended_install</key>
 	<true/>
 	<key>uninstall_method</key>


### PR DESCRIPTION
Even though Munki already checks for blocking applications before trying to update Chrome, there are fringe scenarios in which a stray Chrome process may still be running that may make the installcheck_script think an older version of Chrome is still running, and thus get Munki into an install loop.

This PR adds a postinstall_script to kill any existing Chrome processes after installing Chrome.