### PR TITLE
Fix logic in Chrome installcheck_script to avoid update loop

### DIFF
--- a/pkgsinfo/GoogleChromeInstallCheck.pkginfo
+++ b/pkgsinfo/GoogleChromeInstallCheck.pkginfo
@@ -101,8 +101,8 @@ def main():
     if not running_version:
         print('Chrome is not running and seems up to date')
         sys.exit(1)
-    elif LooseVersion(running_version) &lt; LooseVersion(current_chrome_version):
-        print('Running version is {} and on-disk version is {}'.format(running_version, current_chrome_version))
+    elif LooseVersion(running_version) &lt; LooseVersion(desired_chrome_version):
+        print('Running version is {} and desired version is {}'.format(running_version, desired_chrome_version))
         sys.exit(0)
 
     print('Chrome is running and is up to date')


### PR DESCRIPTION
This PR fixes an issue by which a user could update Chrome, Munki would see that it's mid-update, try to install the old version, and then the user tries to update again, Munki again sees it's mid-update, and then tries to install the old version again.

So the comparison for the running version is "Is it equal to or greater than the desired version?" and not "Is it equal to or greater than the on-disk version (which may be higher than the version in the Munki repo)?"